### PR TITLE
Fix namespace mismatches to match directory structure

### DIFF
--- a/src/DeSerializer/Program.cs
+++ b/src/DeSerializer/Program.cs
@@ -1,4 +1,4 @@
-﻿namespace Serializer
+namespace DeSerializer
 {
     internal static class Program
     {

--- a/src/FACEPALM/Base/Facepalm.cs
+++ b/src/FACEPALM/Base/Facepalm.cs
@@ -5,8 +5,8 @@ using Commons.Database.Handlers;
 using FACEPALM.Exceptions;
 using FACEPALM.Interfaces;
 using FACEPALM.Models;
-using Uploader.Factory;
-using Uploader.Models;
+using FileHandler.Factory;
+using FileHandler.Models;
 
 namespace FACEPALM.Base
 {

--- a/src/FACEPALM/Interfaces/IFacepalm.cs
+++ b/src/FACEPALM/Interfaces/IFacepalm.cs
@@ -1,4 +1,4 @@
-using Uploader.Models;
+using FileHandler.Models;
 
 namespace FACEPALM.Interfaces
 {

--- a/src/FileHandler/Base/FileHandlerBase.cs
+++ b/src/FileHandler/Base/FileHandlerBase.cs
@@ -1,4 +1,4 @@
-namespace Uploader.Base
+namespace FileHandler.Base
 {
     public abstract class FileHandlerBase
     {

--- a/src/FileHandler/Base/IPortalSecret.cs
+++ b/src/FileHandler/Base/IPortalSecret.cs
@@ -1,4 +1,4 @@
-namespace Uploader.Base
+namespace FileHandler.Base
 {
     public interface IPortalSecret;
 }

--- a/src/FileHandler/Enums/StorageProviderTypes.cs
+++ b/src/FileHandler/Enums/StorageProviderTypes.cs
@@ -1,4 +1,4 @@
-namespace Uploader.Enums
+namespace FileHandler.Enums
 {
     public enum StorageProviderTypes
     {

--- a/src/FileHandler/Factory/UploaderFactory.cs
+++ b/src/FileHandler/Factory/UploaderFactory.cs
@@ -1,9 +1,9 @@
-using Uploader.Base;
-using Uploader.Enums;
-using Uploader.Models;
-using Uploader.Uploaders;
+using FileHandler.Base;
+using FileHandler.Enums;
+using FileHandler.Models;
+using FileHandler.Uploaders;
 
-namespace Uploader.Factory
+namespace FileHandler.Factory
 {
     public static class UploaderFactory
     {

--- a/src/FileHandler/Models/CredentialStore.cs
+++ b/src/FileHandler/Models/CredentialStore.cs
@@ -1,9 +1,9 @@
 using Commons.Database.Handlers;
 using System.Data.Common;
 using Commons.Interfaces;
-using Uploader.Enums;
+using FileHandler.Enums;
 
-namespace Uploader.Models
+namespace FileHandler.Models
 {
     public class CredentialStore(
         string uuid,

--- a/src/FileHandler/Models/DropboxSecret.cs
+++ b/src/FileHandler/Models/DropboxSecret.cs
@@ -1,7 +1,7 @@
 using System.Text.Json;
-using Uploader.Base;
+using FileHandler.Base;
 
-namespace Uploader.Models
+namespace FileHandler.Models
 {
     public class DropboxSecret(string refreshToken, string appKey, string appSecret, string folderName) : IPortalSecret
     {

--- a/src/FileHandler/Models/GoogleDriveSecret.cs
+++ b/src/FileHandler/Models/GoogleDriveSecret.cs
@@ -1,7 +1,7 @@
 using System.Text.Json;
-using Uploader.Base;
+using FileHandler.Base;
 
-namespace Uploader.Models
+namespace FileHandler.Models
 {
     //NOT DATABASE CLASS
     public class GoogleDriveSecret(string fileName, string content, string folderId) : IPortalSecret

--- a/src/FileHandler/Uploaders/DropboxFileHandler.cs
+++ b/src/FileHandler/Uploaders/DropboxFileHandler.cs
@@ -1,10 +1,10 @@
 using System.Diagnostics.CodeAnalysis;
 using Dropbox.Api;
 using Dropbox.Api.Files;
-using Uploader.Base;
-using Uploader.Models;
+using FileHandler.Base;
+using FileHandler.Models;
 
-namespace Uploader.Uploaders
+namespace FileHandler.Uploaders
 {
     [ExcludeFromCodeCoverage(Justification =
         "No way to Mock Values Of FileHandler. Will Add Integration tests in the future")]

--- a/src/FileHandler/Uploaders/GoogleDriveHandler.cs
+++ b/src/FileHandler/Uploaders/GoogleDriveHandler.cs
@@ -5,10 +5,10 @@ using Google.Apis.Download;
 using Google.Apis.Drive.v3;
 using Google.Apis.Services;
 using Google.Apis.Upload;
-using Uploader.Base;
+using FileHandler.Base;
 using File = Google.Apis.Drive.v3.Data.File;
 
-namespace Uploader.Uploaders
+namespace FileHandler.Uploaders
 {
     [ExcludeFromCodeCoverage(Justification =
         "No way to Mock Values Of FileHandler. Will Add Integration tests in the future")]

--- a/src/StartupHandler/FirstTimeStartup/CreateTables.cs
+++ b/src/StartupHandler/FirstTimeStartup/CreateTables.cs
@@ -3,7 +3,7 @@ using Commons.Interfaces;
 using Commons.Models;
 using FACEPALM.Models;
 using System.Reflection;
-using Uploader.Models;
+using FileHandler.Models;
 
 namespace StartupHandler.FirstTimeStartup
 {

--- a/src/Tests/FileHandler.Tests/Factory/UploaderFactoryTest.cs
+++ b/src/Tests/FileHandler.Tests/Factory/UploaderFactoryTest.cs
@@ -1,9 +1,9 @@
-using Uploader.Enums;
-using Uploader.Factory;
-using Uploader.Models;
-using Uploader.Uploaders;
+using FileHandler.Enums;
+using FileHandler.Factory;
+using FileHandler.Models;
+using FileHandler.Uploaders;
 
-namespace Uploader.Tests.Factory
+namespace FileHandler.Tests.Factory
 {
     public class UploaderFactoryTest
     {

--- a/src/Tests/FileHandler.Tests/Models/CredentialStoreTest.cs
+++ b/src/Tests/FileHandler.Tests/Models/CredentialStoreTest.cs
@@ -1,9 +1,9 @@
 using System.Data.Common;
 using Moq;
-using Uploader.Enums;
-using Uploader.Models;
+using FileHandler.Enums;
+using FileHandler.Models;
 
-namespace Uploader.Tests.Models
+namespace FileHandler.Tests.Models
 {
     public class CredentialStoreTest
     {

--- a/src/Tests/FileHandler.Tests/Models/DropboxSecretTest.cs
+++ b/src/Tests/FileHandler.Tests/Models/DropboxSecretTest.cs
@@ -1,6 +1,6 @@
-using Uploader.Models;
+using FileHandler.Models;
 
-namespace Uploader.Tests.Models
+namespace FileHandler.Tests.Models
 {
     public class DropboxSecretTest
     {

--- a/src/Tests/FileHandler.Tests/Models/GoogleDriveSecretTest.cs
+++ b/src/Tests/FileHandler.Tests/Models/GoogleDriveSecretTest.cs
@@ -1,6 +1,6 @@
-using Uploader.Models;
+using FileHandler.Models;
 
-namespace Uploader.Tests.Models
+namespace FileHandler.Tests.Models
 {
     public class GoogleDriveSecretTest
     {


### PR DESCRIPTION
- Fixed FileHandler directory files to use FileHandler.* namespaces instead of Uploader.*
- Fixed FileHandler.Tests directory files to use FileHandler.Tests.* namespaces instead of Uploader.Tests.*
- Fixed DeSerializer/Program.cs to use DeSerializer namespace instead of Serializer
- Updated all using statements to reference the correct namespaces
- Ensured namespace consistency across the entire codebase

Changes include:
- FileHandler/Factory/UploaderFactory.cs: Uploader.Factory → FileHandler.Factory
- FileHandler/Models/*: Uploader.Models → FileHandler.Models
- FileHandler/Enums/*: Uploader.Enums → FileHandler.Enums
- FileHandler/Base/*: Uploader.Base → FileHandler.Base
- FileHandler/Uploaders/*: Uploader.Uploaders → FileHandler.Uploaders
- Tests/FileHandler.Tests/*: Uploader.Tests.* → FileHandler.Tests.*
- DeSerializer/Program.cs: Serializer → DeSerializer